### PR TITLE
Point to sims instructions

### DIFF
--- a/install/conda.rst
+++ b/install/conda.rst
@@ -54,7 +54,7 @@ These commands will download and activate the LSST Science Pipelines in a new Co
    conda config --add channels http://conda.lsst.codes/stack  
    conda create --name lsst python=2
    source activate lsst
-   conda install lsst-distrib lsst-sims
+   conda install lsst-distrib
    source eups-setups.sh
 
 Here's what these commands are doing, line-by-line:
@@ -66,8 +66,7 @@ Here's what these commands are doing, line-by-line:
    See the `Conda documentation on environments for more information <http://conda.pydata.org/docs/using/envs.html>`__.
 3. Activate the ``lsst`` environment (use your environment's name if you chose a different one).
    The :command:`activate` command is provided by Anaconda/Miniconda (e.g. at :file:`~/miniconda2/bin/activate`).
-4. Install the full suite of LSST science software, including Science Pipelines (``lsst-distrib``) and LSST Simulations (``lsst-sims``).
-   Installating ``lsst-sims`` is optional.
+4. Install the full suite of LSST science software, including Science Pipelines (``lsst-distrib``).
 5. Setup LSST packages in your environment with EUPS.
 
 .. warning::

--- a/install/conda.rst
+++ b/install/conda.rst
@@ -48,6 +48,10 @@ See the `Conda documentation for more information about installing and managing 
 
 These commands will download and activate the LSST Science Pipelines in a new Conda environment:
 
+.. note::
+    Installing the LSST simulation tools (including MAF) requires pointing to a different conda
+    channel.  See `this page <https://confluence.lsstcorp.org/display/SIM/Catalogs+and+MAF>`_ for instructions.
+
 .. code-block:: bash
    :linenos:
 

--- a/install/index.rst
+++ b/install/index.rst
@@ -12,8 +12,10 @@ Installing the LSST Science Pipelines
 
 We offer a few ways of installing the LSST Science Pipelines.
 Choose an option below to get started.
-Note: to install the LSST simulation tools (including MAF), see
-`this page <https://confluence.lsstcorp.org/display/SIM/Catalogs+and+MAF>`_.
+
+.. note::
+    To install the LSST simulation tools (including MAF), see
+    `this page <https://confluence.lsstcorp.org/display/SIM/Catalogs+and+MAF>`_.
 
 :doc:`Conda installation <conda>`
    Install the Pipelines as an `Anaconda/Miniconda <https://www.continuum.io/why-anaconda>`__ binary package.

--- a/install/index.rst
+++ b/install/index.rst
@@ -12,6 +12,8 @@ Installing the LSST Science Pipelines
 
 We offer a few ways of installing the LSST Science Pipelines.
 Choose an option below to get started.
+Note: to install the LSST simulation tools (including MAF), see
+`this page <https://confluence.lsstcorp.org/display/SIM/Catalogs+and+MAF>`_.
 
 :doc:`Conda installation <conda>`
    Install the Pipelines as an `Anaconda/Miniconda <https://www.continuum.io/why-anaconda>`__ binary package.


### PR DESCRIPTION
This pull request removes mention of lsst-sims from the conda install page and makes a few more explicit mentions of the LSST Sims installation instructions webpage to try to avoid the continuing confusion Re: where to get the conda install of lsst_sims