### PR TITLE
DM-9414: Update macOS build dependencies (cmake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The site will be built in the `_build/` directory.
 
 ## Licensing
 
-Copyright 2015-2016 AURA/LSST
+Copyright 2015-2017 Association of Universities for Research in Astronomy.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
 ![Creative Commons License](https://cdn.rawgit.com/lsst-sqre/lsst_stack_docs/master/_static/cc-by_large.svg?raw=true)

--- a/conf.py
+++ b/conf.py
@@ -61,7 +61,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'LSST Science Pipelines'
-copyright = u'2015-2016 AURA/LSST'
+copyright = u'2015-2017 Association of Universities for Research in Astronomy'
 author = u'LSST Data Management'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/install/newinstall.rst
+++ b/install/newinstall.rst
@@ -18,8 +18,13 @@ If you have difficulty installing LSST software:
 Prerequisites
 =============
 
-**New since 11.0**: The minimum gcc version required to compile the Stack is **gcc 4.8.**
-If you using our previous factory platform, RedHat/CentOS 6, and you are unable to upgrade to version 7 (which comes with gcc 4.8 as default) consult :ref:`the section below on upgrading compilers in legacy Linux <source-install-redhat-legacy>`.
+This section lists system prerequisites for :ref:`macOS <source-install-mac-prereqs>`, :ref:`Debian/Ubuntu <source-install-debian-prereqs>`, and :ref:`RedHat/CentOS <source-install-redhat-prereqs>` platforms.
+All platforms also need :ref:`Python package dependencies <source-install-py-deps>` listed here.
+
+.. note::
+
+   **New since 11.0**: The minimum gcc version required to compile the Stack is **gcc 4.8.**
+   If you using our previous factory platform, RedHat/CentOS 6, and you are unable to upgrade to version 7 (which comes with gcc 4.8 as default) consult :ref:`the section below on upgrading compilers in legacy Linux <source-install-redhat-legacy>`.
 
 .. _source-install-mac-prereqs:
 

--- a/install/newinstall.rst
+++ b/install/newinstall.rst
@@ -4,7 +4,7 @@ Source Installation with newinstall.sh
 
 This page will guide you through installing the LSST Science Pipelines from source with :command:`newinstall.sh` (internally based on :command:`eups distrib`).
 
-The LSST Science Pipelines are officially tested against CentOS 7, however developers regularly use `a variety of Linux and Mac OS X operating systems <https://ls.st/faq>`_.
+The LSST Science Pipelines are officially tested against CentOS 7, however developers regularly use `a variety of Linux and macOS operating systems <https://ls.st/faq>`_.
 
 :doc:`We also offer Conda binaries and Docker images <index>` if you do not wish to install the Science Pipelines from source.
 
@@ -19,14 +19,24 @@ Prerequisites
 =============
 
 **New since 11.0**: The minimum gcc version required to compile the Stack is **gcc 4.8.**
-If you using our previous factory platform, RedHat/CentOS 6, and you are unable to upgrade to version 7 (which comes with gcc 4.8 as default) consult :ref:`the section below on upgrading compilers in legacy Linux. <source-install-redhat-legacy>`.
+If you using our previous factory platform, RedHat/CentOS 6, and you are unable to upgrade to version 7 (which comes with gcc 4.8 as default) consult :ref:`the section below on upgrading compilers in legacy Linux <source-install-redhat-legacy>`.
 
 .. _source-install-mac-prereqs:
 
-Mac OS X
---------
+macOS
+-----
+
+To build LSST software, macOS systems need:
+
+1. :ref:`Xcode <source-install-mac-prereqs-xcode>`, or command line tools.
+2. :ref:`cmake <source-install-mac-prereqs-cmake>`.
 
 Versions prior to OS X 10.9 and earlier have not been tested recently and may not work.
+
+.. _source-install-mac-prereqs-xcode:
+
+Xcode
+^^^^^
 
 You will need to install developer tools, which we recommend you obtain with Apple's Xcode command line tools package.
 To do this, run from the command line (e.g. ``Terminal.app`` or similar):
@@ -41,6 +51,13 @@ You can verify where the tools are installed by running:
 .. code-block:: bash
 
    xcode-select -p
+
+.. _source-install-mac-prereqs-cmake:
+
+cmake
+^^^^^
+
+``cmake`` can be `installed directly <https://cmake.org/download/>`__, or though a package manager like `Homebrew <https://brew.sh>`__.
 
 .. _source-install-debian-prereqs:
 


### PR DESCRIPTION
- [x] Add cmake prereq for macOS (cmake is already listed for Linux distributions)
- ~[ ] Update Python pre-reqs. Perhaps use a Conda manifest from lsstsw, https://github.com/lsst/lsstsw/blob/master/etc/conda2_packages-osx-64.txt~ **DEFERRED.**

https://pipelines.lsst.io/v/DM-9414/install/newinstall.html#macos