### PR TITLE
DM-9815: Stop warnings from becoming errors because of docs.scipy.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
   - pip install -r requirements.txt
   - pip install "ltd-mason>=0.2,<0.3"
 script:
-  - sphinx-build -b html -a -n -W -d _build/doctree . _build/html
+  # TODO Add -W flag (DM-9815)
+  - sphinx-build -b html -a -n -d _build/doctree . _build/html
 after_success:
   - ltd-mason-travis --html-dir _build/html
 env:


### PR DESCRIPTION
The downtime of docs.scipy.org affects intersphinx, and with the `-W` flag those warnings become errors the fail Travis builds.

See also:
https://community.lsst.org/t/how-docs-scipy-org-and-intersphinx-affect-your-doc-builds/1717?u=jsick