### PR TITLE
DM-11936: 14.0 OS Prerequisites

### DIFF
--- a/install/lsstsw.rst
+++ b/install/lsstsw.rst
@@ -19,10 +19,13 @@ If you have difficulty installing LSST software:
 1. Prerequisites
 ================
 
+The LSST Science Pipelines can generally be compiled on CentOS, Debian, and macOS platforms.
+See :ref:`prereq-platforms` for information about LSST's official reference platform and build reports with other platforms.
+
 Before you begin:
 
 - `Install and configure Git LFS <https://developer.lsst.io/tools/git_lfs.html>`_ for LSST DM's data servers.
-- Install prerequisites for your platform: :doc:`macOS <prereqs/macos>`, :doc:`Debian / Ubuntu <prereqs/debian>`, or :doc:`Centos / RedHat <prereqs/centos>`.
+- Install prerequisites for your platform: :doc:`CentOS / RedHat <prereqs/centos>`, :doc:`Debian / Ubuntu <prereqs/debian>`, or :doc:`macOS <prereqs/macos>`.
 - If you opt not to use ``lsstsw`` \’s default Python environment you need to :ref:`install these Python dependencies <python-deps>`.
 
 .. _lsstsw-deploy:

--- a/install/newinstall.rst
+++ b/install/newinstall.rst
@@ -15,12 +15,13 @@ If you have installation issues, here are some ways to get help:
 1. Prerequisites
 ================
 
-You can install the LSST Science Pipelines on CentOS 7 (LSST's reference platform) as well as other Linux distributions and macOS (see the `LSST Stack Testing Status <https://ls.st/faq>`_ for information on the platforms we have tested with).
+The LSST Science Pipelines can be compiled and run on CentOS, Debian, and macOS.
+See :ref:`prereq-platforms` for information about LSST's official reference platform and build reports with other platforms.
 
 Before you begin, install prerequisite software for your platform:
 
 - :doc:`macOS <prereqs/macos>`
-- :doc:`Centos / RedHat <prereqs/centos>`
+- :doc:`CentOS / RedHat <prereqs/centos>`
 - :doc:`Debian / Ubuntu <prereqs/debian>`
 
 ..

--- a/install/prereqs/index.rst
+++ b/install/prereqs/index.rst
@@ -4,6 +4,17 @@ Prerequisites
 
 This page lists software needed to install and use the LSST Science Pipelines.
 
+.. _prereq-platforms:
+
+Platform compatibility
+======================
+
+The LSST Data Management reference platform is CentOS 7-1611.
+This is the platform we officially develop, test, and operate with.
+
+Besides the reference platform, we generally expect the Pipelines to also compile and run under CentOS 6, Debian Linux (including Ubuntu), and macOS.
+See `LSST Stack Testing Status <https://ls.st/faq>`_ reports of building LSST software on various platforms.
+
 .. _system-prereqs:
 
 System prerequisites


### PR DESCRIPTION
Updates reporting on OS compatibility.

- Consolidate OS compatibility reporting to a section in `install/prereqs/` so that both the newinstall and lsstsw-based installation pathways can link to it.
- Identify CentOS 7-1611 at the reference platform (see #55)

Drafts:

- https://pipelines.lsst.io/v/DM-11936/install/prereqs/index.html#platform-compatibility
- https://pipelines.lsst.io/v/DM-11936/install/newinstall.html#prerequisites
- https://pipelines.lsst.io/v/DM-11936/install/lsstsw.html#prerequisites