### PR TITLE
Document the need for flock.

### DIFF
--- a/install/prereqs/index.rst
+++ b/install/prereqs/index.rst
@@ -31,6 +31,15 @@ System prerequisites
 
   **New since 14.0**: The minimum :command:`cmake` version required to compile the Stack is **2.8.12**.
 
+.. _filesystem-prereqs:
+
+Filesystem prerequisites
+========================
+
+Filesystems used for compiling the Stack and hosting output data repositories must support the ``flock`` system call for file locking.
+Local filesystems virtually always have this support.
+Network filesystems are sometimes mounted without such support to improve performance; the output of the :command:`mount` command may show the ``nolock`` or ``noflock`` option in those cases.
+
 .. _python-deps:
 
 Python dependencies


### PR DESCRIPTION
We require that filesystems used for output of certain files (e.g. persisted configurations, schemas, etc.) support the flock system call.  Tests of this capability in `daf_persistence` also require that the build filesystem have the same support.  There does not appear to be a good way to check for filesystem support, so for now documenting this requirement here seems like the best that can be done.