### PR TITLE
Fix incorrect listing commands.

### DIFF
--- a/install/setup.rst
+++ b/install/setup.rst
@@ -47,10 +47,10 @@ To see what packages (and their versions) are currently set up:
 
 .. code-block:: bash
 
-   setup list -s
+   eups list -s
 
 To see all packages that are installed, even if not currently set up, run:
 
 .. code-block:: bash
 
-   setup list
+   eups list


### PR DESCRIPTION
Listing packages uses the `eups` command, not the `setup` command.