### PR TITLE
Update docker.rst to list /home/lsst as container home directory

### DIFF
--- a/install/docker.rst
+++ b/install/docker.rst
@@ -77,13 +77,21 @@ For example:
    docker run -it -v `pwd`:/home/vagrant/mnt lsstsqre/centos:7-stack-lsst_distrib-w_2017_35
 
 The example mounts the current working directory (```pwd```) to the ``/home/vagrant/mnt`` directory in the container.
+
+.. note::
+
+   If you are using a ``w_2017_37``, or later, Docker image, the home directory is ``/home/lsst``.
+   Then the example to mount the current working directory is:
+
+   .. code-block:: bash
+
+      docker run -it -v `pwd`:/home/lsst/mnt lsstsqre/centos:7-stack-lsst_distrib-w_2017_37
+
 If you run :command:`ls` from the container's prompt you should see all files in the current working directory of the host filesystem:
 
 .. code-block:: bash
 
    ls mnt
-
-Note that ``/home/lsst`` is the default home directory for LSST Science Pipelines Docker images.
 
 As usual with interactive mode (``docker run -it``), you can ``exit`` from the container's shell to stop the container and return to the host shell:
 
@@ -167,6 +175,15 @@ These steps show how to run a container and build a LSST Science Pipelines packa
    .. code-block:: bash
 
       docker run -itd -v `pwd`:/home/vagrant/mnt --name lsst lsstsqre/centos:7-stack-lsst_distrib-w_2017_35
+
+   .. note::
+
+      If you are using a ``w_2017_37``, or later, Docker image, the home directory is ``/home/lsst``.
+      Then the example to mount the current working directory is:
+
+      .. code-block:: bash
+
+         docker run -itd -v `pwd`:/home/lsst/mnt --name lsst lsstsqre/centos:7-stack-lsst_distrib-w_2017_37
 
    This starts the container in a detached mode so you can open and exit multiple container shells.
    Follow the steps in :ref:`docker-detached` to open a shell in the container.

--- a/install/docker.rst
+++ b/install/docker.rst
@@ -83,7 +83,7 @@ If you run :command:`ls` from the container's prompt you should see all files in
 
    ls mnt
 
-Note that ``/home/vagrant`` is the default home directory for LSST Science Pipelines Docker images.
+Note that ``/home/lsst`` is the default home directory for LSST Science Pipelines Docker images.
 
 As usual with interactive mode (``docker run -it``), you can ``exit`` from the container's shell to stop the container and return to the host shell:
 


### PR DESCRIPTION
`/home/lsst` is the default user home directory in Docker image `w_2018_06`.  I haven't checked other images.

This line should be changed.  Should the examples be changed to be with respect to `/home/lsst`?

Also, the container opens up in `/opt/lsst/software/stack`.  This is somewhat convenient as you don't have to look up the path for the `loadLSST.bash` script, but perhaps a note to this effect that the containers don't open in the home directory will help the naive user who is completely lost.