### PR TITLE
DM-13723: Update Getting Started tutorial for v15.0

### DIFF
--- a/getting-started/coaddition.rst
+++ b/getting-started/coaddition.rst
@@ -153,10 +153,10 @@ Putting this together, run the following command to warp ``HSC-R``-band exposure
 
 .. code-block:: bash
 
-   makeCoaddTempExp.py DATA  --rerun coadd \
+   makeCoaddTempExp.py DATA --rerun coadd \
        --selectId filter=HSC-R \
        --id filter=HSC-R tract=0 patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2 \
-       --config doApplyUberCal=False
+       --config doApplyUberCal=False doApplySkyCorr=False
 
 .. tip::
 
@@ -164,7 +164,7 @@ Putting this together, run the following command to warp ``HSC-R``-band exposure
 
 .. note::
 
-   Since this tutorial doesn't prepare an uber calibration, you needed to explicitly disable the uber calibration step that is enabled by default for HSC processing.
+   Since this tutorial doesn't prepare an uber calibration or sky correction, you needed to explicitly disable these calibration steps from the default HSC processing configuration.
 
 Next, repeat the warping step for ``HSC-I``-band images:
 
@@ -173,7 +173,7 @@ Next, repeat the warping step for ``HSC-I``-band images:
    makeCoaddTempExp.py DATA --rerun coadd \
        --selectId filter=HSC-I \
        --id filter=HSC-I tract=0 patch=0,0^0,1^0,2^1,0^1,1^1,2^2,0^2,1^2,2 \
-       --config doApplyUberCal=False
+       --config doApplyUberCal=False doApplySkyCorr=False
 
 Coadding warped images
 ======================

--- a/getting-started/data-setup.rst
+++ b/getting-started/data-setup.rst
@@ -140,6 +140,17 @@ Run:
 
       ingestImages.py -h
 
+Install transmission curves
+===========================
+
+Run this command to install transmission curves corresponding to the raw data:
+
+.. code-block:: bash
+
+   installTransmissionCurves.py DATA
+
+Transmission calibrations, like this, are currently a special feature for HSC data `implemented in the obs_subaru package <https://github.com/lsst/obs_subaru/tree/master/hsc/transmission>`_.
+
 Ingesting calibrations into the Butler repository
 =================================================
 

--- a/getting-started/data-setup.rst
+++ b/getting-started/data-setup.rst
@@ -60,16 +60,6 @@ First, clone `ci_hsc`_ using Git:
 .. code-block:: bash
 
    git clone https://github.com/lsst/ci_hsc
-   cd ci_hsc
-   git checkout -b tutorial ffa10de
-   cd ..
-
-.. note::
-
-   We're specifically checking out the ``ffa10de`` commit of ``ci_hsc`` to be compatible with the v14.0 release of the LSST Science Pipelines.
-
-   If you're using a newer version of the Pipelines, it should be fine to use the ``master`` branch.
-   However, if you don't see *r*-band images listed in later steps, that's because the v14.0 Pipelines cannot read the compressed FITS images in the ``ci_hsc`` repository.
 
 Then :command:`setup` the package to add it to the EUPS stack:
 

--- a/getting-started/display.rst
+++ b/getting-started/display.rst
@@ -138,11 +138,20 @@ To display the ``calexp`` you will use the display framework, which is imported 
    import lsst.afw.display as afwDisplay
 
 The display framework provides a uniform API for multiple display backends, including DS9_ and LSST's Firefly viewer.
-For this tutorial you'll create a display with the ``ds9`` backend:
+The default backend is ``ds9``, so you can create a display like this:
 
 .. code-block:: python
 
-   display = afwDisplay.getDisplay(backend='ds9')
+   display = afwDisplay.getDisplay()
+
+.. note::
+
+   You can choose a different backend by setting the ``backend`` parameter.
+   For example:
+
+   .. code-block:: python
+
+      display = afwDisplay.getDisplay(backend='firefly')
 
 Display the calexp (calibrated exposure)
 ========================================

--- a/getting-started/photometry.rst
+++ b/getting-started/photometry.rst
@@ -115,7 +115,7 @@ This command created a ``deepCoadd_ref`` dataset.
 
 .. _getting-started-tutorial-forced-coadds:
 
-Running Forced photometry on coadds
+Running forced photometry on coadds
 ===================================
 
 Now you have accurate positions for all detected sources in the coadds.

--- a/getting-started/processccd.rst
+++ b/getting-started/processccd.rst
@@ -108,4 +108,4 @@ Here are some key takeaways:
   Reruns (``--rerun`` argument) are a convenient way to create output data repositories.
   Make sure that all datasets in a rerun are processed consistently.
 
-Continue this tutorial in :doc:`part 2, where you'll learn how display these calibrated exposures <display>`.
+Continue this tutorial in :doc:`part 3, where you'll learn how display these calibrated exposures <display>`.


### PR DESCRIPTION
This PR fixes some API changes that impact the Getting Started tutorial

- [x] Use `master` branch of `ci_hsc` (It'd be better to use a tag of `ci_hsc`)
- [x] `installTransmissionCurves.py`
- [x] ds9 is the default display backend
- [x] `doApplySkyCorr=False`

Note: `15_0_rc2` at least has a bug that affects `makeCoaddTempExp.py`. We're talking about it over on Slack dm-science-pipelines. Depending on whether that's resolvable, we may need to temporarily remove the Getting Started tutorial from the v15 release (or post a warning of some sort).