### PR TITLE
DM-14921: Remove Python 2.7 mentions from installation docs

### DIFF
--- a/install/lsstsw.rst
+++ b/install/lsstsw.rst
@@ -41,7 +41,7 @@ Begin by choosing a working directory, then deploy ``lsstsw`` into it:
    ./bin/deploy
    source bin/setup.sh
 
-For more information about the :command:`deploy` command, such as using Python 2.7 instead of Python 3, see :ref:`lsstsw-about-deploy`.
+For more information about the :command:`deploy` command, see :ref:`lsstsw-about-deploy`.
 
 .. _lsstsw-rebuild:
 
@@ -123,7 +123,6 @@ Next steps and advanced topics
 ==============================
 
 - :ref:`lsstsw-about-deploy`.
-- :ref:`lsstsw-py2`.
 - :ref:`lsstsw-about-rebuild`.
 - :ref:`lsstsw-branches`.
 - :ref:`lsstsw-deploy-ref`.
@@ -137,10 +136,8 @@ About the lsstsw deploy script
 The ``deploy`` script automates several things to prepare an LSST development environment:
 
 1. Installs Git.
-3. Installs a Miniconda_ Python environment specific to this lsstsw workspace.
-   The default Python is Python 3, but you can switch to Python 2.7 if necessary.
-   See :ref:`lsstsw-py2`.
 2. Installs Git LFS (*you* are still responsible for :doc:`configuring it <git-lfs>`).
+3. Installs a Miniconda_ Python 3 environment specific to this lsstsw workspace.
 4. Installs EUPS_ into :file:`eups/current/`.
 5. Clones `lsst-build`_, which runs the build process.
 6. Clones versiondb_, a robot-managed Git repository of package dependency information.
@@ -150,19 +147,6 @@ This environment, including the EUPS, Miniconda, Git, and Git LFS software, is o
 Otherwise, lsstsw does not affect the software installed on your computer.
 
 See also: :ref:`lsstsw-deploy-ref`.
-
-.. _lsstsw-py2:
-
-How to use Python 2.7
----------------------
-
-The lsstsw :command:`deploy` script installs Miniconda_ as self-contained Python environment.
-By default, :command:`deploy` installs a Python 3 version of Miniconda_.
-For testing Python 2.7 compatibility, you can create an lsstsw deployment with a Python 2.7 version of Miniconda using the :option:`deploy -2` argument:
-
-.. code-block:: bash
-
-   ./bin/deploy -2
 
 .. _lsstsw-about-rebuild:
 
@@ -218,7 +202,7 @@ lsstsw deploy command reference
 
 .. option:: -2
 
-   Install a Python 2-based Miniconda_.
+   Install a Python 2-based Miniconda_ (not supported for ``v16_0`` of the LSST Science Pipelines and later)
 
 .. option:: -3
 

--- a/install/lsstsw.rst
+++ b/install/lsstsw.rst
@@ -137,10 +137,10 @@ About the lsstsw deploy script
 The ``deploy`` script automates several things to prepare an LSST development environment:
 
 1. Installs Git.
-2. Installs Git LFS (*you* are still responsible for `configuring it <http://developer.lsst.io/en/latest/tools/git_lfs.html>`_).
 3. Installs a Miniconda_ Python environment specific to this lsstsw workspace.
    The default Python is Python 3, but you can switch to Python 2.7 if necessary.
    See :ref:`lsstsw-py2`.
+2. Installs Git LFS (*you* are still responsible for :doc:`configuring it <git-lfs>`).
 4. Installs EUPS_ into :file:`eups/current/`.
 5. Clones `lsst-build`_, which runs the build process.
 6. Clones versiondb_, a robot-managed Git repository of package dependency information.

--- a/install/newinstall.rst
+++ b/install/newinstall.rst
@@ -77,8 +77,6 @@ Then load the LSST software environment into your shell:
 
    Here are ways to customize the :command:`newinstall.sh` installation for specific needs:
 
-   - The default Python environment is Python 3.6.
-     **Python 2.7 users,** see :ref:`newinstall-py2`.
    - :ref:`newinstall-user-python`.
    - The recommended installation uses precompiled binary tarballs if they're available for your platform (and falls back to a source build).
      See :ref:`newinstall-binary-packages`.
@@ -158,7 +156,6 @@ These topics provide additional information about the installation and ways to c
 - :ref:`newinstall-unset-variables`.
 - :ref:`newinstall-background`.
 - :ref:`newinstall-miniconda`.
-- :ref:`newinstall-py2`.
 - :ref:`newinstall-user-python`.
 - :ref:`newinstall-binary-packages`.
 - :ref:`newinstall-find-binaries`.
@@ -219,8 +216,7 @@ This Python installation isn't required, but we recommend it.
 See :ref:`newinstall-user-python` if required.
 
 The Python environment installed by :command:`newinstall.sh` is Miniconda_, a minimal version of Anaconda_.
-By default, :command:`newinstall.sh` installs Python 3.5.2.
-If you need to work with your own Python 2.7-only packages, see :ref:`newinstall-py2`.
+By default, :command:`newinstall.sh` installs Python 3.6.
 
 In this Miniconda environment, :command:`newinstall.sh` installs the Science Pipeline's Python prerequisites.
 See :ref:`python-deps` for more information.
@@ -231,24 +227,6 @@ The LSST Miniconda environment is only active when you source the ``loadLSST`` s
 If you install other Python packages in a shell where the LSST Miniconda is activated (with :command:`pip install` or :command:`conda install`) those packages are installed into the LSST Miniconda's :file:`site-packages`, not your system's.
 The Python installed by :command:`newinstall.sh` works like an isolated Python environment dedicated to LSST Science Pipelines code and your own related modules---effectively like a `Conda environment <https://conda.io/docs/user-guide/concepts.html#conda-environments>`_ or Python `venv <https://docs.python.org/3/library/venv.html>`_.
 This pattern is useful because it reduces the risk of having Python package version incompatibilities.
-
-.. _newinstall-py2:
-
-How to install a Python 2.7 environment with newinstall.sh
-----------------------------------------------------------
-
-LSST Science Pipelines is backwards compatible with Python 2.7.
-If you need to run your own Python 2.7-only Python packages in conjunction with the Pipelines, you can have :command:`newinstall.sh` install a Python 2.7 environment for you instead of the default Python 3.5 environment.
-
-To select Python 2.7, run :command:`newinstall.sh` with the :option:`-2 <newinstall.sh -2>` flag (in addition to other flags, like :option:`-t <newinstall.sh -t>`):
-
-.. code-block:: bash
-
-   bash newinstall.sh -2
-
-Then follow the remaining instructions at :ref:`newinstall-run`.
-
-See also: :ref:`newinstall-miniconda`.
 
 .. _newinstall-user-python:
 
@@ -290,10 +268,11 @@ EUPS distrib binary packages are currently being built for these platform combin
    :header: "OS","Compiler","Python"
 
    "macOS ``osx/10.9``", "``clang-800.0.42.1``", "``miniconda3-4.2.12`` (Python 3)"
-   "macOS ``osx/10.9``", "``clang-800.0.42.1``", "``miniconda2-4.2.12`` (Python 2)"
+   "macOS ``osx/10.9``", "``clang-800.0.42.1``", "``miniconda3-4.2.21`` (Python 3)"
+   "Redhat ``redhat/el7``", "``devtoolset-6``", "``miniconda3-4.2.21`` (Python 3)"
    "Redhat ``redhat/el7``", "``gcc-system``", "``miniconda3-4.2.12`` (Python 3)"
-   "Redhat ``redhat/el7``", "``gcc-system``", "``miniconda2-4.2.12`` (Python 2)"
-   "Redhat ``redhat/el6``", "``devtoolset-3``", "``miniconda2-4.2.12`` (Python 2)"
+   "Redhat ``redhat/el7``", "``gcc-system``", "``miniconda3-4.2.21`` (Python 3)"
+   "Redhat ``redhat/el6``", "``devtoolset-6``", "``miniconda3-4.2.21`` (Python 3)"
 
 When you run :command:`newinstall.sh`, it looks at your system to identify your operating system and compiler.
 The version of :command:`newinstall.sh` you run also determines the Miniconda_ version and the lsstsw_ build system versions.
@@ -448,7 +427,7 @@ newinstall.sh argument reference
 
 .. option:: -2
 
-   Use Python 2 if the script is installing its own Python.
+   Use Python 2 if the script is installing its own Python (unsupported by the LSST Science Pipelines ``v16_0`` and newer).
 
 .. option:: -3
 

--- a/install/prereqs/index.rst
+++ b/install/prereqs/index.rst
@@ -45,13 +45,13 @@ Network filesystems are sometimes mounted without such support to improve perfor
 Python dependencies
 ===================
 
+The LSST Science Pipelines require Python 3.6 or newer.
+
 Both the :doc:`newinstall.sh <../newinstall>` and :doc:`lsstsw <../lsstsw>`\ -based installation methods provide dedicated Miniconda environments pre-loaded with Python dependencies.
 If you opt to use your own Python, you can re-create the default Python environment made by :command:`newinstall.sh` and ``lsstsw`` with these Conda environments:
 
-- `macOS and Python 2.7 <https://github.com/lsst/lsstsw/blob/master/etc/conda2_packages-osx-64.txt>`_.
-- `macOS and Python 3.5+ <https://github.com/lsst/lsstsw/blob/master/etc/conda3_packages-osx-64.txt>`_.
-- `Linux and Python 2.7 <https://github.com/lsst/lsstsw/blob/master/etc/conda2_packages-linux-64.txt>`_.
-- `Linux and Python 3.5+ <https://github.com/lsst/lsstsw/blob/master/etc/conda3_packages-linux-64.txt>`_.
+- `macOS <https://github.com/lsst/lsstsw/blob/master/etc/conda3_packages-osx-64.txt>`_.
+- `Linux <https://github.com/lsst/lsstsw/blob/master/etc/conda3_packages-linux-64.txt>`_.
 
 .. _optional-deps:
 


### PR DESCRIPTION
With `v16_0` and newer, Python 2.7 is no longer supported. The baseline is Python 3.6.

This PR removes all instructions for installing with Python 2.7.

Also updates the EUPS package roots table.