### PR TITLE
DM-15872: Incorporate AP documentation into pipelines.lsst.io

### DIFF
--- a/ups/pipelines_lsst_io.table
+++ b/ups/pipelines_lsst_io.table
@@ -1,6 +1,9 @@
 # Specify direct dependencies to all packages included in the documentation.
 # Sort alphabetically for maintainability.
 setupRequired(afw)
+setupRequired(ap_association)
+setupRequired(ap_pipe)
+setupRequired(ap_verify)
 setupRequired(base)
 setupRequired(coadd_chisquared)
 setupRequired(coadd_utils)


### PR DESCRIPTION
This PR adds the three `ap_*` packages to the documentation build.