### PR TITLE
Streamline contrib info in README

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -30,24 +30,33 @@ The `Stack section of the DM Developer Guide <https://developer.lsst.io/index.ht
 Building the documentation
 ==========================
 
-`Documenteer <https://documenteer.lsst.io>`__ is the build tool for LSST's Sphinx-based documentation (like this project).
-Depending on whether you're building pipelines.lsst.io as a whole, or just a single package, you can follow one of these tutorials to build and test your documentation changes:
+pipelines.lsst.io_ is automatically built and deployed with each ``lsst_distrib`` release.
+As a contributor, you don't need to worry about updating the published site after you've merged updates to the documentation.
+
+If you're writing new content, it's useful to be able to preview your changes.
+Depending on whether you're building pipelines.lsst.io_ as a whole, or just a single package, you can follow one of these tutorials to build and test your documentation changes:
 
 - `Building single-package documentation locally <https://developer.lsst.io/stack/building-single-package-docs.html>`__.
 - `Building the pipelines.lsst.io site locally <https://developer.lsst.io/stack/building-pipelines-lsst-io-locally.html>`__.
 - `Building pipelines.lsst.io with Jenkins <https://developer.lsst.io/stack/building-pipelines-lsst-io-with-documenteer-job.html>`__.
+
+**Tip:** The Jenkins-based method enables you to publish a preview of the pipelines.lsst.io site based on your ticket branch, which is useful for code reviews.
+This method only works for branches on the `lsst/pipelines_lsst_io <https://github.com/lsst/pipelines_lsst_io>`__ repository itself, though.
 
 Reference documentation for the build commands:
 
 - `stack-docs <https://documenteer.lsst.io/pipelines/stack-docs-cli.html>`__: used to build https://pipelines.lsst.io from the `lsst/pipelines_lsst_io <https://github.com/lsst/pipelines_lsst_io>`__ repository itself.
 - `package-docs <https://documenteer.lsst.io/pipelines/package-docs-cli.html>`__: used to build documentation for single packages from their ``doc/`` directories.
 
+*Background:* `Documenteer <https://documenteer.lsst.io>`__ is the build tool for LSST's Sphinx-based documentation (like this project).
 To get a sense of how all this all works, you can read the `Overview of the Stack documentation system <https://developer.lsst.io/stack/documentation-system-overview.html>`__.
 
 Getting help with contributions
 ===============================
 
-Whether you have general questions about contributing to pipelines.lsst.io, or need help with a specific piece of documentation that you're contributing, you can get help a couple different ways:
+Whether you have general questions about contributing to pipelines.lsst.io_, or need help with a specific piece of documentation that you're contributing, you can get help a couple different ways:
 
 - Ask a question in `#dm-docs <https://lsstc.slack.com/archives/dm-docs>`__ on Slack.
 - Ask a question in the `Data Management category <https://community.lsst.org/c/dm>`__ on the LSST Community forum.
+
+.. _pipelines.lsst.io: https://pipelines.lsst.io

--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@
 
 This repository, combined with content from the `doc/` directories of individual LSST Science Pipelines packages, is what you see at [pipelines.lsst.io](https://pipelines.lsst.io).
 
-[pipelines.lsst.io](https://pipelines.lsst.io) is automatically built by LSST's Jenkins CI for each `lsst_distrib` release (major, weekly, and daily releases).
-You can find builds for each tagged release by visiting https://pipelines.lsst.io/v.
+[pipelines.lsst.io](https://pipelines.lsst.io) is automatically built by LSST's Jenkins CI for each `lsst_distrib` release (major, weekly, and daily releases):
+
+- The main site, https://pipelines.lsst.io, tracks the latest major release.
+- The latest weekly release is published at https://pipelines.lsst.io/v/weekly/
+- The latest daily release is published at https://pipelines.lsst.io/v/daily/
+
+You can find links for all editions of this documentation by visiting https://pipelines.lsst.io/v.
 
 ## Contributing to pipelines.lsst.io
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,17 @@
 
 This repository, combined with content from the `doc/` directories of individual LSST Science Pipelines packages, is what you see at [pipelines.lsst.io](https://pipelines.lsst.io).
 
-Other related documentation and resources:
+[pipelines.lsst.io](https://pipelines.lsst.io) is automatically built by LSST's Jenkins CI for each `lsst_distrib` release (major, weekly, and daily releases).
+You can find builds for each tagged release by visiting https://pipelines.lsst.io/v.
+
+## Contributing to pipelines.lsst.io
+
+To learn how to contribute to the [pipelines.lsst.io](https://pipelines.lsst.io) documentation by reporting issues or contributing pull requests, see the [CONTRIBUTING](./.github/CONTRIBUTING.rst) file.
+
+## Related projects and resources
 
 - [LSST Community forum](https://community.lsst.org)
 - [DM Developer Guide](https://developer.lsst.io)
-
-## How the site is built
-
-This site is built automatically for each `lsst_distrib` release by the [sqre/infra/documenteer](https://ci.lsst.codes/blue/organizations/jenkins/sqre%2Finfra%2Fdocumenteer/activity) Jenkins job.
-You can find builds for each tagged release by visiting https://pipelines.lsst.io/v.
-
-This documentation is built by [Sphinx](http://www.sphinx-doc.org/en/master/) and LSST's own [Documenteer](https://documenteer.lsst.io).
-You can read an [Overview of the Stack documentation system](https://developer.lsst.io/stack/documentation-system-overview.html).
-
-## Contributing
-
-For links on how to contribute to the pipelines.lsst.io documentation, see the [CONTRIBUTING](./.github/CONTRIBUTING.rst) file.
 
 ## Licensing
 


### PR DESCRIPTION
It turned out that linking to the Jenkins job in the README, it enticed a developer to try running that Jenkins job without going through the documentation to learn how to why to use it, creating a lot of confusion.

Now the README focuses on just saying that the docs are built automatically, and then links to the CONTRIBUTING file that can more carefully guide developers through how to build the documentation.