### PR TITLE
DM-16398: Update to documenteer 0.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[pipelines]==0.4.1
+documenteer[pipelines]==0.4.2


### PR DESCRIPTION
This documenteer release patches the `lsst-task-api-summary` directive to handle cases where an object doesn't have a docstring at all.