### PR TITLE
DM-17065: Automatically version installation docs from EUPS_TAG environment variable

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -10,5 +10,4 @@ from documenteer.sphinxconfig.stackconf import \
 
 globals().update(build_pipelines_lsst_io_configs(
     project_name='LSST Science Pipelines',
-    current_release='v16_0')
-)
+))

--- a/getting-started/data-setup.rst
+++ b/getting-started/data-setup.rst
@@ -26,11 +26,10 @@ Install the LSST Science Pipelines
 
 If you haven't already, you'll need to install the LSST Science Pipelines.
 We recommend that you install the pre-built binary packages by following the instructions at :doc:`/install/newinstall`.
-This tutorial is intended to work with the latest release (|current-release|).
+This tutorial is intended to work with |eups-tag-mono| tag of the ``lsst_distrib`` EUPS package.
 
 When working with the LSST Science Pipelines, you need to remember to activate the installation and *set up* the package stack in each new shell session.
 Follow the instructions :doc:`/install/setup` to do this.
-We recommend that you use ``lsst_distrib`` as a general top-level package.
 
 To make sure the environment is set up properly, you can run:
 

--- a/index.rst
+++ b/index.rst
@@ -5,7 +5,9 @@ The LSST Science Pipelines
 The LSST Science Pipelines enable optical and near-infrared astronomy in the big data era.
 We are building the Science Pipelines for the `Large Synoptic Survey Telescope (LSST) <http://lsst.org>`_, but our command line task and Python API can be extended for any optical or near-infrared dataset.
 
-The latest release is |current-release|: :doc:`learn what's new <releases/index>`.
+This documentation covers version |current-version|.
+:doc:`Learn what's new <releases/index>`.
+You can also find the documentation for `other versions <https://pipelines.lsst.io/v>`__.
 
 .. _part-getting-started:
 

--- a/index.rst
+++ b/index.rst
@@ -5,9 +5,9 @@ The LSST Science Pipelines
 The LSST Science Pipelines enable optical and near-infrared astronomy in the big data era.
 We are building the Science Pipelines for the `Large Synoptic Survey Telescope (LSST) <http://lsst.org>`_, but our command line task and Python API can be extended for any optical or near-infrared dataset.
 
-This documentation covers version |current-version|.
+This documentation covers version |eups-tag-bold|.
 :doc:`Learn what's new <releases/index>`.
-You can also find the documentation for `other versions <https://pipelines.lsst.io/v>`__.
+You can also find documentation for `other versions <https://pipelines.lsst.io/v>`__.
 
 .. _part-getting-started:
 

--- a/install/demo.rst
+++ b/install/demo.rst
@@ -26,20 +26,22 @@ For example:
 
 Then download the demo's data (if you aren't running the current stable release, see the note below):
 
-.. code-block:: bash
-
-   curl -L https://github.com/lsst/lsst_dm_stack_demo/archive/16.0.tar.gz | tar xvzf -
-   cd lsst_dm_stack_demo-16.0
-
-.. note::
-
-   The demo's version should match your installed software.
-   If you installed from source (with :doc:`lsstsw <lsstsw>`) or with a :ref:`newer tag <newinstall-other-tags>`, clone the demo repository instead of downloading a release:
+.. jinja:: default
 
    .. code-block:: bash
 
-      git clone https://github.com/lsst/lsst_dm_stack_demo.git
-      cd lsst_dm_stack_demo
+      curl -L https://github.com/lsst/lsst_dm_stack_demo/archive/{{ pipelines_demo_ref }}.tar.gz | tar xvzf -
+      cd lsst_dm_stack_demo-{{ pipelines_demo_ref }}
+
+.. caution::
+
+   The demo's version should match your LSST Science Pipelines installed software.
+   If you installed from source (with :doc:`lsstsw <lsstsw>`) or with a :ref:`newer tag <newinstall-other-tags>`, you'll likely need to run the latest version of the demo (``master`` branch):
+
+   .. code-block:: bash
+
+      curl -L https://github.com/lsst/lsst_dm_stack_demo/archive/master.tar.gz | tar xvzf -
+      cd lsst_dm_stack_demo-master
 
 The demo repository consumes roughly 41 MB, contains input images, reference data, and configuration files.
 The demo script will process SDSS images from two fields in Stripe 82, as shown in the following table:

--- a/install/docker.rst
+++ b/install/docker.rst
@@ -26,13 +26,15 @@ Docker's `Getting Started <https://docs.docker.com/get-started/>`_ documentation
 Quick start
 ===========
 
-This command downloads a :ref:`weekly build <docker-tags>` of the LSST Science Pipelines, starts a container, and opens a prompt:
+This command downloads a current version of the LSST Science Pipelines Docker image (see also :ref:`docker-tags`), starts a container, and opens a prompt:
 
-.. code-block:: bash
+.. jinja:: default
 
-   docker run -ti lsstsqre/centos:7-stack-lsst_distrib-v16_0
+   .. code-block:: bash
 
-Then in the container's shell, load the LSST environment and set up a :doc:`top-level package <top-level-packages>` (``lsst_distrib`` in this case):
+      docker run -ti lsstsqre/centos:7-stack-lsst_distrib-{{ release_eups_tag }}
+
+Then in the container's shell, load the LSST environment and activate the ``lsst_distrib`` top-level package:
 
 .. code-block:: bash
 
@@ -72,9 +74,11 @@ This is useful for processing data with the LSST Science Pipelines and even deve
 To mount a local directory, add a ``-v <host directory>/<mount directory>`` argument to the :command:`docker run` command.
 For example:
 
-.. code-block:: bash
+.. jinja:: default
 
-   docker run -it -v `pwd`:/home/lsst/mnt lsstsqre/centos:7-stack-lsst_distrib-v16_0
+   .. code-block:: bash
+
+      docker run -it -v `pwd`:/home/lsst/mnt lsstsqre/centos:7-stack-lsst_distrib-{{ release_eups_tag }}
 
 The example mounts the current working directory (```pwd```) to the ``/home/lsst/mnt`` directory in the container.
 
@@ -104,9 +108,11 @@ With a detached container, the container won't stop until you specify it.
 
 To get started, run the container with the ``-d`` flag (**detached**):
 
-.. code-block:: bash
+.. jinja:: default
 
-   docker run -itd --name lsst lsstsqre/centos:7-stack-lsst_distrib-v16_0
+   .. code-block:: bash
+
+      docker run -itd --name lsst lsstsqre/centos:7-stack-lsst_distrib-{{ release_eups_tag }}
 
 You still use the ``-it`` arguments to put the container in interactive mode, even though Docker doesn't immediately open a container prompt for you.
 
@@ -163,9 +169,11 @@ These steps show how to run a container and build a LSST Science Pipelines packa
 
 2. **From the host shell,** start the container with the current working directory mounted:
 
-   .. code-block:: bash
+   .. jinja:: default
 
-      docker run -itd -v `pwd`:/home/lsst/mnt --name lsst lsstsqre/centos:7-stack-lsst_distrib-v16_0
+      .. code-block:: bash
+
+         docker run -itd -v `pwd`:/home/lsst/mnt --name lsst lsstsqre/centos:7-stack-lsst_distrib-{{ release_eups_tag }}
 
    This starts the container in a detached mode so you can open and exit multiple container shells.
    Follow the steps in :ref:`docker-detached` to open a shell in the container.
@@ -241,15 +249,17 @@ The schema of these tags is:
 
 For example:
 
-.. code-block:: text
+.. jinja:: default
 
-   7-stack-lsst_distrib-w_2017_35
+   .. code-block:: text
 
-This tag corresponds to:
+      7-stack-lsst_distrib-{{ release_eups_tag }}
 
-- CentOS 7 operating system.
-- ``lsst_distrib`` :doc:`top-level package <top-level-packages>`.
-- ``w_2017_35`` EUPS tag. See :ref:`newinstall-other-tags` for an overview of LSST's EUPS tag schema.
+   This tag corresponds to:
+
+   - CentOS 7 operating system.
+   - ``lsst_distrib`` :doc:`top-level package <top-level-packages>`.
+   - ``{{ release_eups_tag }}`` EUPS tag. See :ref:`newinstall-other-tags` for an overview of LSST's EUPS tag schema.
 
 You can see what tags are available by browsing `lsstsqre/centos on Docker Hub <https://hub.docker.com/r/lsstsqre/centos/tags/>`_.
 

--- a/install/newinstall.rst
+++ b/install/newinstall.rst
@@ -53,10 +53,12 @@ If you need to reuse a shell, see :ref:`newinstall-unset-variables`.
 Next, run :command:`newinstall.sh` to set up the environment you'll install the LSST Science Pipelines into.
 For most use cases we recommend downloading and running :command:`newinstall.sh` like this:
 
-.. code-block:: bash
+.. jinja:: default
 
-   curl -OL https://raw.githubusercontent.com/lsst/lsst/16.0/scripts/newinstall.sh
-   bash newinstall.sh -ct
+   .. code-block:: bash
+
+      curl -OL https://raw.githubusercontent.com/lsst/lsst/{{ newinstall_ref }}/scripts/newinstall.sh
+      bash newinstall.sh -ct
 
 Always execute :command:`newinstall.sh` with :command:`bash`, as shown, regardless of what shell you're in.
 
@@ -94,15 +96,16 @@ Then load the LSST software environment into your shell:
 4. Install Science Pipelines packages
 =====================================
 
-Install the LSST Science Pipelines packages by running :command:`eups distrib install` for a :doc:`top-level package <top-level-packages>` and a tagged version.
+.. jinja:: default
 
-This example installs the ``v16_0`` tagged version (current release) of the ``lsst_distrib`` :doc:`top-level package <top-level-packages>`:
+   The LSST Science Pipelines is distributed as the ``lsst_distrib`` EUPS package.
+   Install the current version, ``{{ release_eups_tag }}``:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   eups distrib install -t v16_0 lsst_distrib
-   curl -sSL https://raw.githubusercontent.com/lsst/shebangtron/master/shebangtron | python
-   setup lsst_distrib
+      eups distrib install -t {{ release_eups_tag }} lsst_distrib
+      curl -sSL https://raw.githubusercontent.com/lsst/shebangtron/master/shebangtron | python
+      setup lsst_distrib
 
 If prebuilt binaries are available for your platform (and you ran :command:`newinstall.sh` with the :option:`-t <newinstall.sh -t>` argument) the installation should take roughly 10 minutes.
 Otherwise, the installation falls back to a source build that can take two hours, depending on the top-level package and your machine's performance.
@@ -116,10 +119,7 @@ See :doc:`setup` for more information.
 
 .. note::
 
-   - ``lsst_distrib`` is a top-level package that provides most LSST Data Management pipelines software, but other top-level packages may be more applicable for your work, such as ``lsst_apps`` or ``lsst_sims``.
-     See :doc:`top-level-packages` for more information.
-
-   - ``v16_0`` is the current release.
+   - |eups-tag-mono| is the current version corresponding to this documentation.
      You can install other tagged versions of the LSST Science Pipelines, though.
      See :ref:`newinstall-other-tags`.
 

--- a/install/prereqs/index.rst
+++ b/install/prereqs/index.rst
@@ -50,8 +50,12 @@ The LSST Science Pipelines require Python 3.6 or newer.
 Both the :doc:`newinstall.sh <../newinstall>` and :doc:`lsstsw <../lsstsw>`\ -based installation methods provide dedicated Miniconda environments pre-loaded with Python dependencies.
 If you opt to use your own Python, you can re-create the default Python environment made by :command:`newinstall.sh` and ``lsstsw`` with these Conda environments:
 
-- `macOS <https://github.com/lsst/lsstsw/blob/10a4fa6/etc/conda3_packages-osx-64.txt>`_.
-- `Linux <https://github.com/lsst/lsstsw/blob/10a4fa6/etc/conda3_packages-linux-64.txt>`_.
+.. jinja:: default
+
+   - `macOS <https://github.com/lsst/scipipe_conda_env/blob/{{ scipipe_conda_ref }}/etc/conda3_packages-osx-64.txt>`_.
+   - `Linux <https://github.com/lsst/scipipe_conda_env/blob/{{ scipipe_conda_ref }}/etc/conda3_packages-linux-64.txt>`_.
+
+   These conda environments are maintained in the `lsst/scipipe_conda_env <https://github.com/lsst/scipipe_conda_env/tree/{{ scipipe_conda_ref }}>`__ repository.
 
 .. _optional-deps:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[pipelines]==0.5.0a2
+documenteer[pipelines]==0.5.0a3


### PR DESCRIPTION
This PR dynamically versions installation documentation based on the value of the EUPS_TAG environment variable in the build environment. Examples of versioning are:

- URL of `newinstall.sh` file
- EUPS tag
- URL of demo repo archive
- Docker tags
- URL to conda environments

Thus the daily and weekly builds will have accurate installation information, rather than falling back to the old major release info.

This PR depends on PR https://github.com/lsst-sqre/documenteer/pull/60

This work is also currently blocked by an issue with the behavior of the EUPS_TAG variable in Jenkins (it is always `current`, rather than being the specific EUPS tag being built).

You can see a live build of this at https://pipelines.lsst.io/v/DM-17065/ In that deployment, the `EUPS_TAG` variable is `d_2019_02_07`.