### PR TITLE
 Add a link to Doxygen API reference site under the "Modules" homepage section

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -58,7 +58,7 @@ To install the LSST Simulation software, such as MAF, please follow the `LSST Si
 
    install/index
 
-.. _part-packages:
+.. _part-modules:
 
 Python modules
 ==============
@@ -66,6 +66,8 @@ Python modules
 .. module-toctree::
 
 Additional C++ API reference documentation is currently available at the `doxygen.lsst.codes <http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/namespaces.html>`__ site.
+
+.. _part-packages:
 
 Packages
 ========

--- a/index.rst
+++ b/index.rst
@@ -65,6 +65,8 @@ Python modules
 
 .. module-toctree::
 
+Additional C++ API reference documentation is currently available at the `doxygen.lsst.codes <http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/namespaces.html>`__ site.
+
 Packages
 ========
 


### PR DESCRIPTION
This should make the temporary Doxygen API reference site more visible in the interim.

Implements @jdswinbank's suggestion from #117.