### PR TITLE
Add rsync to ubuntu dependencies

### DIFF
--- a/install/prereqs/debian.rst
+++ b/install/prereqs/debian.rst
@@ -29,6 +29,7 @@ Debian or Ubuntu systems require the following packages:
        m4 \
        make \
        perl-modules \
+       rsync \
        zlib1g-dev
 
 .. from https://github.com/lsst-sqre/puppet-lsststack/blob/master/manifests/params.pp


### PR DESCRIPTION
Necessary for `fftw`'s `eupspkg.cfg.sh`