### PR TITLE
DM-20850: Add a general index and an index of available tasks

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -102,6 +102,8 @@ Indices
    Tasks <tasks>
 
 - :doc:`Tasks <tasks>`
+- :ref:`genindex`
+- :ref:`Search <search>`
 
 More info
 =========

--- a/index.rst
+++ b/index.rst
@@ -90,6 +90,19 @@ Release details
    known-issues
    metrics
 
+.. _part-indices:
+
+Indices
+=======
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   Tasks <tasks>
+
+- :doc:`Tasks <tasks>`
+
 More info
 =========
 

--- a/tasks.rst
+++ b/tasks.rst
@@ -1,0 +1,45 @@
+.. _task-index:
+
+##########
+Task index
+##########
+
+.. _pipelinetask-index:
+
+Pipeline tasks
+==============
+
+.. lsst-pipelinetasks::
+   :root: lsst
+
+.. _commandlinetask-index:
+
+Command-line tasks
+==================
+
+.. lsst-cmdlinetasks::
+   :root: lsst
+
+.. _regular-task-index:
+
+Tasks
+=====
+
+.. lsst-tasks::
+   :root: lsst
+
+.. _configurables-index:
+
+Configurables
+=============
+
+.. lsst-configurables::
+   :root: lsst
+
+.. _configs-index:
+
+Configs
+=======
+
+.. lsst-configs::
+   :root: lsst


### PR DESCRIPTION
[See the Indices section of the draft documentation](https://pipelines.lsst.io/v/DM-20850/index.html#indices).

The [Task index](https://pipelines.lsst.io/v/DM-20850/tasks.html) is made using [our directives for listing tasks](https://documenteer.lsst.io/sphinxext/lssttasks.html#topic-listings) and other objects in the task framework.

The [general index](https://pipelines.lsst.io/v/DM-20850/genindex.html) is built by Sphinx itself and currently indexes all objects documented by domains (namely Python APIs and command-line interfaces). In the future we can start using the [index directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#index-generating-markup) to start creating a curated index of concepts.

The Indices section could also be expanded in the future with a link to a [glossary](http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#glossary).