### PR TITLE
Hotfix the v20 release tags

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -11,3 +11,24 @@ from documenteer.sphinxconfig.stackconf import \
 globals().update(build_pipelines_lsst_io_configs(
     project_name='LSST Science Pipelines',
 ))
+
+# Patch EUPS tag subsitutions
+rst_epilog = """
+
+.. |eups-tag| replace:: v20_0_0
+.. |eups-tag-mono| replace:: ``v20_0_0``
+.. |eups-tag-bold| replace:: **v20_0_0**
+"""
+
+# Patch EUPS and Git tag context for Jinja templating
+jinja_contexts = {
+    "default": {
+        "release_eups_tag": "v20_0_0",
+        "release_git_ref": "20.0.0",
+        "version": "v20_0_0",
+        "release": "v20_0_0",
+        "scipipe_conda_ref": "20.0.0",
+        "pipelines_demo_ref": "20.0.0",
+        "newinstall_ref": "20.0.0",
+    }
+}


### PR DESCRIPTION
The `EUPS_TAG` environment variable in the build environment no longer encodes specific version information so for the 20.0.0 release we need to manually set this information.