### PR TITLE
DM-30882: Include a gen 2 deprecation notice for tutorials

### DIFF
--- a/gen2tutorialdeprecation.txt
+++ b/gen2tutorialdeprecation.txt
@@ -1,0 +1,4 @@
+.. warning::
+
+   These tutorials are based on the deprecated Generation 2 command-line task and Butler (`lsst.daf.persistence.Butler`).
+   New tutorials for Generation 3 pipeline tasks and `lsst.daf.butler.Butler` are coming soon.

--- a/getting-started/coaddition.rst
+++ b/getting-started/coaddition.rst
@@ -15,6 +15,8 @@ In this part of the :ref:`tutorial series <getting-started-tutorial>` you will c
 To do this you'll first define the pixel frame that you'll mosaic into, called a **sky map**, and then warp (reproject) images into that sky map.
 Finally, you will coadd the warped images together into deep images.
 
+.. include:: /gen2tutorialdeprecation.txt
+
 Set up
 ======
 

--- a/getting-started/data-setup.rst
+++ b/getting-started/data-setup.rst
@@ -21,6 +21,8 @@ In this :ref:`tutorial series <getting-started-tutorial>` you will calibrate and
 In this first part of the :ref:`tutorial series <getting-started-tutorial>` you'll set up the LSST Science Pipelines software, and collect the raw observations and calibration data needed for the tutorial.
 Along the way, you'll be introduced to the Butler, which is the Pipelines' interface for managing, reading, and writing datasets.
 
+.. include:: /gen2tutorialdeprecation.txt
+
 Install the LSST Science Pipelines
 ==================================
 

--- a/getting-started/display.rst
+++ b/getting-started/display.rst
@@ -9,6 +9,8 @@
 Getting started tutorial part 3: displaying exposures and source tables output by processCcd.py
 ###############################################################################################
 
+.. include:: /gen2tutorialdeprecation.txt
+
 In the :doc:`previous tutorial <processccd>` in the :ref:`series <getting-started-tutorial>` you used :command:`processCcd.py` to calibrate a set of raw Hyper Suprime-Cam images.
 Now you'll learn how to use the LSST Science Pipelines to inspect :command:`processCcd.py`\ ’s outputs by displaying images and source catalogs in the `DS9 image viewer`_.
 In doing so, you'll be introduced to some of the LSST Science Pipelines' Python APIs, including:

--- a/getting-started/index.rst
+++ b/getting-started/index.rst
@@ -11,6 +11,8 @@ Before you start working with the LSST Science Pipelines, these pages will help 
 Getting started tutorials
 =========================
 
+.. include:: /gen2tutorialdeprecation.txt
+
 In this tutorial series we'll process a set of Hyper Suprime-Cam images into deep coadditions and source catalogs.
 These tutorials will give you a feeling for data processing and analysis with the Science Pipelines.
 

--- a/getting-started/multiband-analysis.rst
+++ b/getting-started/multiband-analysis.rst
@@ -12,6 +12,8 @@ Getting started tutorial part 6: analyzing measurement catalogs in multiple band
 In this part of the :ref:`tutorial series <getting-started-tutorial>` you'll analyze the forced photometry measurement catalogs you created in :doc:`step 5 <photometry>`.
 You'll learn how to work with measurement tables and plot color-magnitude diagrams (CMDs).
 
+.. include:: /gen2tutorialdeprecation.txt
+
 Set up
 ======
 

--- a/getting-started/photometry.rst
+++ b/getting-started/photometry.rst
@@ -11,6 +11,8 @@
 Getting started tutorial part 5: measuring sources
 ##################################################
 
+.. include:: /gen2tutorialdeprecation.txt
+
 In this step of the :ref:`tutorial series <getting-started-tutorial>` you'll measure the coadditions you assembled in :doc:`part 4 <coaddition>` to build catalogs of stars and galaxies.
 This is the measurement strategy:
 

--- a/getting-started/processccd.rst
+++ b/getting-started/processccd.rst
@@ -15,6 +15,8 @@ In this part of the :ref:`tutorial series <getting-started-tutorial>` you'll pro
 We'll use the :command:`processCcd.py` command-line task to remove instrumental signatures with dark, bias and flat field calibration images.
 :command:`processCcd.py` will also use the reference catalog to establish a preliminary WCS and photometric zeropoint solution.
 
+.. include:: /gen2tutorialdeprecation.txt
+
 Set up
 ======
 

--- a/index.rst
+++ b/index.rst
@@ -14,6 +14,8 @@ You can also find documentation for `other versions <https://pipelines.lsst.io/v
 Getting started
 ===============
 
+.. include:: /gen2tutorialdeprecation.txt
+
 If you're new to the LSST Science Pipelines, these step-by-step data processing tutorials will get you up and running:
 
 - Data processing tutorial series: Part 1 :doc:`Data repositories <getting-started/data-setup>` · Part 2 :doc:`Single frame processing <getting-started/processccd>` · Part 3 :doc:`Image and catalog display <getting-started/display>` · Part 4 :doc:`Image coaddition <getting-started/coaddition>` · Part 5 :doc:`Source measurement <getting-started/photometry>` · Part 6 :doc:`Multi-band catalog analysis <getting-started/multiband-analysis>`.


### PR DESCRIPTION
This change adds a gen2 middleware deprecation notice to the getting started tutorials.

This merge affects the `master` branch. Another PR will also backport this change to the current v21 documentation.