### PR TITLE
DM-33516: Update release notes for 23.0.1

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -15,21 +15,21 @@ globals().update(build_pipelines_lsst_io_configs(
 # Patch EUPS tag subsitutions
 rst_epilog = """
 
-.. |eups-tag| replace:: v23_0_0
-.. |eups-tag-mono| replace:: ``v23_0_0``
-.. |eups-tag-bold| replace:: **v23_0_0**
+.. |eups-tag| replace:: v23_0_1
+.. |eups-tag-mono| replace:: ``v23_0_1``
+.. |eups-tag-bold| replace:: **v23_0_1**
 """
 
 # Patch EUPS and Git tag context for Jinja templating
 jinja_contexts = {
     "default": {
-        "release_eups_tag": "v23_0_0",
-        "release_git_ref": "23.0.0",
-        "version": "v23_0_0",
-        "release": "v23_0_0",
-        "scipipe_conda_ref": "23.0.0",
-        "pipelines_demo_ref": "23.0.0",
-        "newinstall_ref": "23.0.0",
+        "release_eups_tag": "v23_0_1",
+        "release_git_ref": "23.0.1",
+        "version": "v23_0_1",
+        "release": "v23_0_1",
+        "scipipe_conda_ref": "23.0.1",
+        "pipelines_demo_ref": "23.0.1",
+        "newinstall_ref": "23.0.1",
     }
 }
 

--- a/releases/tickets/v23_0_0.rst
+++ b/releases/tickets/v23_0_0.rst
@@ -1,6 +1,24 @@
 .. _release-v23-0-0-tickets:
 
 ###################################
+Tickets Addressed in Release 23.0.1
+###################################
+
+- `DM-31611 <https://jira.lsstcorp.org/browse/DM-31611>`_: Improve reproducibility in faro ellipKPM test_te1 [faro]
+- `DM-32034 <https://jira.lsstcorp.org/browse/DM-32034>`_: Create MatchProbabilistic (Pipeline)Task [meas_astrom, pipe_tasks]
+- `DM-32199 <https://jira.lsstcorp.org/browse/DM-32199>`_: If submit or prepare, have bps check early that WMS is in environment. [ctrl_bps]
+- `DM-32625 <https://jira.lsstcorp.org/browse/DM-32625>`_: Activate guards on SFM PSF quality for inclusion in coaddition for LSSTCam-imSim [obs_lsst, obs_subaru, pipe_tasks]
+- `DM-32675 <https://jira.lsstcorp.org/browse/DM-32675>`_: Improvement PanDA plugin on using iDDS [ctrl_bps]
+- `DM-32827 <https://jira.lsstcorp.org/browse/DM-32827>`_: skyCorr backgrounds are not get applied during gen3 makeWarp [pipe_tasks]
+- `DM-32830 <https://jira.lsstcorp.org/browse/DM-32830>`_: panda_auth_reset [ctrl_bps]
+- `DM-32895 <https://jira.lsstcorp.org/browse/DM-32895>`_: Add matchObjectToTruth to obs_lsst's imsim DRP.yaml [obs_lsst]
+- `DM-33195 <https://jira.lsstcorp.org/browse/DM-33195>`_: Update forcedPhotCoadd to use the correct input image in Gen3 [meas_base]
+- `DM-33200 <https://jira.lsstcorp.org/browse/DM-33200>`_: Fix lsst.afw.geom usage in two afw rst documents [afw]
+- `DM-33339 <https://jira.lsstcorp.org/browse/DM-33339>`_: pipetask is always doing fail-fast in single-process mode [ctrl_mpexec]
+- `DM-33345 <https://jira.lsstcorp.org/browse/DM-33345>`_: Investigate extremely slow execution butler creation [pipe_base]
+- `DM-33786 <https://jira.lsstcorp.org/browse/DM-33786>`_: assembleCoadd reports success even when some stripes are unsuccessful. [pipe_task]
+
+###################################
 Tickets Addressed in Release 23.0.0
 ###################################
 

--- a/releases/v23_0_0.rst
+++ b/releases/v23_0_0.rst
@@ -2,7 +2,7 @@
 .. _release-v23-0-0:
 
 ###########################
-Release 23.0.0 (2021-12-21)
+Release 23.0.1 (2022-04-06)
 ###########################
 
 .. toctree::
@@ -13,16 +13,19 @@ Release 23.0.0 (2021-12-21)
 +-------------------------------------------+------------+
 | Source                                    | Identifier |
 +===========================================+============+
-| Git tag                                   | 23.0.0     |
+| Git tag                                   | 23.0.1     |
 +-------------------------------------------+------------+
-| :doc:`EUPS distrib </install/newinstall>` | v23\_0\_0  |
+| :doc:`EUPS distrib </install/newinstall>` | v23\_0\_1  |
 +-------------------------------------------+------------+
 
 
-This release is based on the ``w_2021_40`` weekly build, with 29 tickets backported to support the Data Preview 0.2 data release.
+This release is based on the ``w_2021_40`` weekly build (September 30, 2021), with 42 tickets backported to 23.0.1 to support the Data Preview 0.2 Data Release (DP0.2).
+For the production of DP0.2, 23.0.0 was used for single-frame processing (the Tasks within the Pipeline subsets ``step1`` and ``step2``), and 23.0.1 was used for coadd-processing (Tasks within the Pipeline subset ``step3``).
+None of the updates to 23.0.1 affect single-frame processing, such that rerunning a data release with the final minor release will produce the same results as the DP0.2.
 
 The notes below highlight significant technical changes to the Science Pipelines codebase in this release.
 For a complete list of changes made, see :doc:`tickets/v23_0_0`.
+The 13 tickets that were backported after 23.0.0 (released December 21, 2021) are listed first.
 
 The `Characterization Metric Report (DMTR-351) <https://dmtr-351.lsst.io/>`_ describes the scientific performance of this release in terms of scientific performance metrics.
 


### PR DESCRIPTION
Updated existing 23.0.0 page rather than making a new one
because 23.0.1 is a patch for 23.0.0. We do not expect or
recommend than anyone use 23.0.0 for any reason. For
reproducing DP0.2, the results of single frame processing
will be the same with 23.0.1 and 23.0.0, as this patch includes
no behavior changes to single frame processing.