### PR TITLE
DM-34954: Update to documenteer 0.5.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[pipelines]>=0.5.0,<0.6.0
+documenteer[pipelines]>=0.5.11,<0.6.0


### PR DESCRIPTION
This allows us to use numpydoc 1.2, which fixes an incompatibility with Python 3.10.

Full adoption of Documenteer 0.6 and later is still to come.