### PR TITLE
DM-38140: Adopt documenteer.conf.pipelines config

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,18 +1,18 @@
 """Sphinx configurations for pipeline_lsst_io.
 
 These configurations are centrally defined in Documenteer
-(https://github.com/lsst-sqre/documenteer).
+(https://github.com/lsst-sqre/documenteer). Documentation:
+https://documenteer.lsst.io/pipelines/configuration.html
 """
 
-from documenteer.sphinxconfig.stackconf import \
-    build_pipelines_lsst_io_configs
+from documenteer.conf.pipelines import *
 
+project = "LSST Science Pipelines"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project
 
-globals().update(build_pipelines_lsst_io_configs(
-    project_name='LSST Science Pipelines',
-))
-
-# Patch EUPS tag subsitutions
+# Patch EUPS tag substitutions
 rst_epilog = """
 
 .. |eups-tag| replace:: v24_0_0
@@ -32,17 +32,3 @@ jinja_contexts = {
         "newinstall_ref": "24.0.0",
     }
 }
-
-# Patch preset configuration of the matplotlib plot directive from
-# documenteer. In documenteer 0.5 we automatically configure the docs
-# with this extension, but in documenteer 0.6 we stopped adding this
-# extension by default because of compatibility issues with the latest
-# Sphinx. Once we move the Pipelines docs build in ci.lsst.codes to
-# Documenteer 0.6+ we can drop this patch.
-try:
-    import matplotlib.sphinxext.plot_directive
-    mpl_ext_name = matplotlib.sphinxext.plot_directive.__name__
-    if mpl_ext_name in extensions:  # noqa F821
-        extensions.remove(mpl_ext_name)  # noqa F821
-except ImportError:
-    pass


### PR DESCRIPTION
This configuration is available with documenteer 0.6+, which we're now using from rubin-env-developer.

This provides a forward migration route to incorporating the Doxygen build into the site, solves issues with Python recursion issues.