### PR TITLE
DM-36162: Add intersphinx entry for networkx.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -32,3 +32,6 @@ jinja_contexts = {
         "newinstall_ref": "24.0.0",
     }
 }
+
+# needed for pipe_base
+intersphinx_mapping['networkx'] = ('https://networkx.org/documentation/stable/', None)


### PR DESCRIPTION
networkx is a graph library used in some `pipe_base` APIs; it was added to the `pipe_base` documentation build on lsst/pipe_base#317.