### PR TITLE
DM-40150: Remove deprecated middleware API call to getDirect

### DIFF
--- a/getting-started/data-setup.rst
+++ b/getting-started/data-setup.rst
@@ -113,7 +113,7 @@ Now you can explore the repository using the registry attribute of the Butler yo
    for col in registry.queryCollections():
        print(col)
    for ref in registry.queryDatasets('raw', collections='HSC/raw/all', instrument='HSC'):
-       print(ref.dataId.mapping)
+       print(ref.dataId)
 
 Read more about querying datasets :ref:`here <daf_butler_queries>`.
 

--- a/getting-started/data-setup.rst
+++ b/getting-started/data-setup.rst
@@ -113,7 +113,7 @@ Now you can explore the repository using the registry attribute of the Butler yo
    for col in registry.queryCollections():
        print(col)
    for ref in registry.queryDatasets('raw', collections='HSC/raw/all', instrument='HSC'):
-       print(ref.dataId.full)
+       print(ref.dataId.mapping)
 
 Read more about querying datasets :ref:`here <daf_butler_queries>`.
 

--- a/getting-started/display.rst
+++ b/getting-started/display.rst
@@ -384,7 +384,7 @@ You can use the iterator returned by ``queryDatasets`` to make a simple movie, b
    display = afwDisplay.getDisplay()
    collection = f"u/{os.environ['USER']}/single_frame"
    for ref in butler.registry.queryDatasets('calexp', physical_filter='HSC-R', collections=collection, instrument='HSC'):
-       calexp = butler.getDirect(ref)
+       calexp = butler.get(ref)
        display.mtv(calexp)
        sleep(1)
 

--- a/getting-started/display.rst
+++ b/getting-started/display.rst
@@ -95,7 +95,7 @@ Now, use the Butler client to find what data IDs are available for the ``calexp`
    import os
    collection = f"u/{os.environ['USER']}/single_frame"
    for ref in butler.registry.queryDatasets('calexp', physical_filter='HSC-R', collections=collection, instrument='HSC'):
-       print(ref.dataId.mapping)
+       print(ref.dataId)
 
 The printed output are data IDs for the ``calexp`` datasets with the ``HSC-R`` physical filter.
 The ``collections`` and ``instrument`` arguments are both required in this case.

--- a/getting-started/display.rst
+++ b/getting-started/display.rst
@@ -95,7 +95,7 @@ Now, use the Butler client to find what data IDs are available for the ``calexp`
    import os
    collection = f"u/{os.environ['USER']}/single_frame"
    for ref in butler.registry.queryDatasets('calexp', physical_filter='HSC-R', collections=collection, instrument='HSC'):
-       print(ref.dataId.full)
+       print(ref.dataId.mapping)
 
 The printed output are data IDs for the ``calexp`` datasets with the ``HSC-R`` physical filter.
 The ``collections`` and ``instrument`` arguments are both required in this case.

--- a/middleware/faq.rst
+++ b/middleware/faq.rst
@@ -152,8 +152,6 @@ Because there are usually many datasets in a data repository (even in a single c
 
 `~Registry.queryDatasets` usually *isn't* what you want if you're looking for raw-image metadata (use `~Registry.queryDimensionRecords` instead); it's easy to confuse the dimensions that represent observations with instances of the ``raw`` dataset type, because they are always ingested into the data repository together.
 
-In Python, you should almost always use `Butler.getDirect` instead of `Butler.get` to actually load the `DatasetRef` instances the query returns; `Butler.get` would repeat some of the work the query already performed.
-
 queryDataIds
 ------------
 

--- a/releases/v25_0_0.rst
+++ b/releases/v25_0_0.rst
@@ -175,7 +175,7 @@ The ``get_bool_array`` method in ``lsst.afw.table.BaseColumnView`` and its deriv
 Pending deprecations in lsst.daf.butler
 ---------------------------------------
 
-The methods ``Butler.put``, ``Butler.get`` and ``Butler.getDeferred`` should be replaced by ``Butler.putDirect``, ``Butler.getDirect`` and ``Butler.getDeferred``.
+The methods ``Butler.put``, ``Butler.get`` and ``Butler.getDeferred`` have been updated and should now replace calls to ``Butler.putDirect``, ``Butler.getDirect`` and ``Butler.getDeferred``, which are being removed.
 ``Butler.datasetExistsDirect`` will be replaced by ``Butler.stored``. ``Butler.datasetExists`` will be replaced by ``Butler.exists``.
 The ``Butler.datastore`` property will be deprecated.
 The ``DimensionPacker`` class will be deprecated in v26.0.0 in favor of configurable dimension packers.


### PR DESCRIPTION
Also fixed v25 change log. @mwittgen this will need to be backported to the v25 branch.