### PR TITLE
DM-47809: Add section with links to external documentation sites

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -98,6 +98,15 @@ Packages
 
 .. _part-release-details:
 
+External documentation
+======================
+
+Several packages which are used by the LSST Science Pipelines are documented separately:
+
+- `astro_metadata_translator <https://astro-metadata-translator.lsst.io>`_ - provides generalized infrastructure for handling metadata extraction for astronomical instrumentation
+- `SDM Schemas <https://sdm-schemas.lsst.io>`_ - contains YAML files representing the Rubin Science Data Model (SDM) Schemas
+- `Felis <https://felis.lsst.io>`_ - reads and validates the SDM Schemas YAML files into Python objects
+
 Release details
 ===============
 


### PR DESCRIPTION
Provide links to packages included in the Science Pipelines which are documented by external websites, including astro_metadata_translator, sdm_schemas, and felis.