### PR TITLE
SP-1861: Help DM with their "getting started" tutorial by checking how it fails with v28

### DIFF
--- a/getting-started/coaddition.rst
+++ b/getting-started/coaddition.rst
@@ -115,7 +115,8 @@ If you wish to pare down the data to be processed, you can specify a data query 
 Coadding warped images
 ======================
 
-Now you'll assemble the warped images into coadditions for each patch with the ``assembleCoadd`` pipeline.
+Now you will select warped images to include in the coadds using the ``selectDeepCoaddVisits`` task, then assemble the warped images into coadditions for each patch with the ``assembleCoadd`` pipeline. 
+Note that the two pipelines (``selectDeepCoaddVisits`` and ``assembleCoadd``) can be specified in a single call to ``pipetask`` by providing ``#selectDeepCoaddVisits,assembleCoadd`` in the call to ``pipetask``.
 As before, we will run without a data query to process a subset of the data, but a selection can be made with the ``-d`` argument just as with warping.
 In this case the ``-d`` argument could be omitted since the coaddition process will only find the warped images from the previous command and will thus only produce coadds for those patches.
 
@@ -127,7 +128,7 @@ Run:
    -b $RC2_SUBSET_DIR/SMALL_HSC/butler.yaml \
    -i u/$USER/warps \
    -o u/$USER/coadds \
-   -p $DRP_PIPE_DIR/pipelines/HSC/DRP-RC2_subset.yaml#assembleCoadd \
+   -p $DRP_PIPE_DIR/pipelines/HSC/DRP-RC2_subset.yaml#selectDeepCoaddVisits,assembleCoadd \
    -d "skymap = 'hsc_rings_v1' AND tract = 9813 AND patch in (38, 39, 40, 41)"
 
 .. tip::

--- a/getting-started/data-setup.rst
+++ b/getting-started/data-setup.rst
@@ -26,7 +26,7 @@ Install the LSST Science Pipelines
 
 If you haven't already, you'll need to install the LSST Science Pipelines.
 We recommend that you install the pre-built binary packages by following the instructions at :doc:`/install/lsstinstall`.
-This tutorial was developed using the ``w_2021_33`` tag of the ``lsst_distrib`` EUPS package.
+This tutorial was developed using the ``v28_0_0`` tag (which is based on ``w_2024_42``) of the ``lsst_distrib`` EUPS package.
 We expect the tutorials to also work with newer versions of the science pipelines, however continuing development will eventually outpace the directions contained here.
 
 When working with the LSST Science Pipelines, you need to remember to activate the installation and *set up* the package stack in each new shell session.

--- a/getting-started/uber-cal.rst
+++ b/getting-started/uber-cal.rst
@@ -71,7 +71,7 @@ E.g.:
    -b $RC2_SUBSET_DIR/SMALL_HSC/butler.yaml \
    -i u/$USER/single_frame \
    -o u/$USER/gbdes \
-   -p $DRP_PIPE_DIR/pipelines/HSC/DRP-RC2_subset.yaml#GbdesAstrometricFitTask
+   -p $DRP_PIPE_DIR/pipelines/HSC/DRP-RC2_subset.yaml#gbdesAstrometricFit
 
 Note the input collection is the same as you passed to ``FGCM`` since ``gbdes`` doesn't depend on any of the outputs of ``FGCM``.
 


### PR DESCRIPTION
There were two steps that were not working as written:

1. `GbdesAstrometricFitTask` has been replaced with `gbdesAstrometricFit`
2. Coaddition now requires `selectDeepCoaddVisits` to be run before `assembleCoadd`.

With these two changes in place, I otherwise confirmed that the tutorial succeeds with `v28_0_0_rc2`.